### PR TITLE
Match system theme

### DIFF
--- a/Bloxstrap/Dialogs/Preferences.cs
+++ b/Bloxstrap/Dialogs/Preferences.cs
@@ -20,6 +20,7 @@ namespace Bloxstrap.Dialogs
             { "Legacy (2011 - 2014)", BootstrapperStyle.LegacyDialog2011 },
             { "Progress (~2014)", BootstrapperStyle.ProgressDialog },
             { "Progress (Dark)", BootstrapperStyle.ProgressDialogDark },
+            { "Match system theme", BootstrapperStyle.SystemTheme }
         };
 
         private static readonly IReadOnlyDictionary<string, BootstrapperIcon> SelectableIcons = new Dictionary<string, BootstrapperIcon>()

--- a/Bloxstrap/Enums/BootstrapperStyle.cs
+++ b/Bloxstrap/Enums/BootstrapperStyle.cs
@@ -1,4 +1,5 @@
-﻿using Bloxstrap.Dialogs.BootstrapperStyles;
+﻿using Microsoft.Win32;
+using Bloxstrap.Dialogs.BootstrapperStyles;
 
 namespace Bloxstrap.Enums
 {
@@ -9,6 +10,7 @@ namespace Bloxstrap.Enums
         LegacyDialog2011,
         ProgressDialog,
         ProgressDialogDark,
+        SystemTheme,
     }
 
     public static class BootstrapperStyleEx
@@ -38,6 +40,20 @@ namespace Bloxstrap.Enums
 
                 case BootstrapperStyle.ProgressDialogDark:
                     dialog = new ProgressDialogDark(bootstrapper);
+                    break;
+
+                case BootstrapperStyle.SystemTheme:
+                    bool darkMode = false;
+                    using (RegistryKey? key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"))
+                    {
+                        var value = key?.GetValue("AppsUseLightTheme");
+                        if (value != null)
+                        {
+                            darkMode = (int)value <= 0;
+                        }
+                    }
+
+                    dialog = !darkMode ? new ProgressDialog(bootstrapper) : new ProgressDialogDark(bootstrapper);
                     break;
             }
 


### PR DESCRIPTION
Automatically match Bloxstrap's theme to progress light/dark mode based on system default app theme