### PR TITLE
Add GitHub Actions workflow & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        platform: [x64, x86]
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.x'
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Publish
+      run: dotnet publish -p:PublishSingleFile=true -r win-${{ matrix.platform }} -c ${{ matrix.configuration }} --self-contained false .\Bloxstrap\Bloxstrap.csproj
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: Bloxstrap (${{ matrix.configuration }}, ${{ matrix.platform }})
+        path: |
+          .\Bloxstrap\bin\${{ matrix.configuration }}\net6.0-windows\win-${{ matrix.platform }}\publish\*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    tags:
+      - 'v*'
+    branches:
+      - main
   pull_request:
     branches: [ main ]
 
@@ -32,3 +35,32 @@ jobs:
         name: Bloxstrap (${{ matrix.configuration }}, ${{ matrix.platform }})
         path: |
           .\Bloxstrap\bin\${{ matrix.configuration }}\net6.0-windows\win-${{ matrix.platform }}\publish\*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download x64 release artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Bloxstrap (Release, x64)
+          path: x64
+      - name: Download x86 release artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Bloxstrap (Release, x86)
+          path: x86
+      - name: Rename binaries
+        run: |
+          mv x64/Bloxstrap.exe Bloxstrap-${{ github.ref_name }}-x64.exe
+          mv x86/Bloxstrap.exe Bloxstrap-${{ github.ref_name }}-x86.exe
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            Bloxstrap-${{ github.ref_name }}-x64.exe
+            Bloxstrap-${{ github.ref_name }}-x86.exe
+          name: Bloxstrap ${{ github.ref_name }}


### PR DESCRIPTION
Related to https://github.com/pizzaboxer/bloxstrap/issues/47#issuecomment-1321106799

- Dependabot to automatically bump dependencies
- Add GitHub Actions workflow to build in every push and create a draft release on tag push. Everything works as intended, as tested in my [fork](https://github.com/sitiom/bloxstrap).

I will add the Winget Releaser action once the next version is released.