### PR TITLE
Fix permission denied error upon attempting to init pizzaboxer/wpfui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wpfui"]
 	path = wpfui
-	url = git@github.com:pizzaboxer/wpfui.git
+	url = https://github.com/pizzaboxer/wpfui

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wpfui"]
 	path = wpfui
-	url = https://github.com/pizzaboxer/wpfui
+	url = https://github.com/pizzaboxer/wpfui/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wpfui"]
 	path = wpfui
-	url = https://github.com/pizzaboxer/wpfui/
+	url = https://github.com/pizzaboxer/wpfui.git


### PR DESCRIPTION
Previously, running `git submodule update --init --recursive` would result in this:
```
Submodule 'wpfui' (git@github.com:pizzaboxer/wpfui.git) registered for path 'wpfui'
Cloning into 'D:/Development/Side Projects/bloxstrap/wpfui'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:pizzaboxer/wpfui.git' into submodule path 'D:/Development/Side Projects/bloxstrap/wpfui' failed
Failed to clone 'wpfui'. Retry scheduled
Cloning into 'D:/Development/Side Projects/bloxstrap/wpfui'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:pizzaboxer/wpfui.git' into submodule path 'D:/Development/Side Projects/bloxstrap/wpfui' failed
Failed to clone 'wpfui' a second time, aborting
```

This was a result of an incorrect submodule url in .gitmodules:
```md
[submodule "wpfui"]
	path = wpfui
	url = git@github.com:pizzaboxer/wpfui.git **bad!**
```