### PR TITLE
Align the logo on the heading with the text on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/pizzaboxer/bloxstrap/raw/main/Images/Bloxstrap.png" width="48"/> Bloxstrap
+# <img src="https://github.com/pizzaboxer/bloxstrap/raw/main/Images/Bloxstrap.png" width="48" style="margin-bottom:-10.63px"/> Bloxstrap
 [![License](https://img.shields.io/github/license/pizzaboxer/bloxstrap)](https://github.com/pizzaboxer/bloxstrap/blob/main/LICENSE)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/pizzaboxer/bloxstrap/ci.yml?branch=main&label=builds)](https://github.com/pizzaboxer/bloxstrap/actions)
 [![Downloads](https://img.shields.io/github/downloads/pizzaboxer/bloxstrap/total)](https://github.com/pizzaboxer/bloxstrap/releases)


### PR DESCRIPTION
Might just be OCD, but I don't like how it currently is where the logo's position is higher than the text. Figured this might fix it. Written in a bit of a hurry, better fixes are appreciated.

A view of the change if commit can't show it: https://github.com/PlayerValley/bloxstrap/tree/patch-1