### PR TITLE
Implement Direct3D10 rendering mode.

### DIFF
--- a/Bloxstrap/Singletons/FastFlagManager.cs
+++ b/Bloxstrap/Singletons/FastFlagManager.cs
@@ -20,6 +20,7 @@ namespace Bloxstrap.Singletons
         {
             { "Automatic", "" },
             { "Direct3D 11", "FFlagDebugGraphicsPreferD3D11" },
+            { "Direct3D 10", "FFlagDebugGraphicsPreferD3D11FL10" },
             { "Vulkan", "FFlagDebugGraphicsPreferVulkan" },
             { "OpenGL", "FFlagDebugGraphicsPreferOpenGL" }
         };
@@ -120,9 +121,14 @@ namespace Bloxstrap.Singletons
             if (GetValue("DFIntTaskSchedulerTargetFps") is null)
                 SetValue("DFIntTaskSchedulerTargetFps", 9999);
 
-            // reshade / exclusive fullscreen requires direct3d 11 to work
-            if (GetValue(RenderingModes["Direct3D 11"]) != "True" && App.FastFlags.GetValue("FFlagHandleAltEnterFullscreenManually") == "False")
-                SetRenderingMode("Direct3D 11");
+            // exclusive fullscreen requires direct3d 10/11 to work
+            if (App.FastFlags.GetValue("FFlagHandleAltEnterFullscreenManually") == "False")
+            {
+                if (!(App.FastFlags.GetValue("FFlagDebugGraphicsPreferD3D11") == "True" || App.FastFlags.GetValue("FFlagDebugGraphicsPreferD3D11FL10") == "True"))
+                {
+                    SetRenderingMode("Direct3D 11");
+                }
+            }
         }
 
         public override void Save()

--- a/Bloxstrap/ViewModels/FastFlagsViewModel.cs
+++ b/Bloxstrap/ViewModels/FastFlagsViewModel.cs
@@ -53,7 +53,11 @@ namespace Bloxstrap.ViewModels
 
                 if (value)
                 {
-                    App.FastFlags.SetRenderingMode("Direct3D 11");
+                    if (!(App.FastFlags.GetValue("FFlagDebugGraphicsPreferD3D11") == "True" || App.FastFlags.GetValue("FFlagDebugGraphicsPreferD3D11FL10") == "True"))
+                    {
+                        App.FastFlags.SetRenderingMode("Direct3D 11");
+                    }
+
                     OnPropertyChanged(nameof(SelectedRenderingMode));
                 }
             }

--- a/Bloxstrap/Views/Pages/FastFlagsPage.xaml
+++ b/Bloxstrap/Views/Pages/FastFlagsPage.xaml
@@ -65,7 +65,7 @@
             <ui:CardControl.Header>
                 <StackPanel>
                     <TextBlock FontSize="14" Text="Enable exclusive fullscreen" />
-                    <TextBlock Margin="0,2,0,0" FontSize="12" Text="Enables using Alt + Enter to enter exclusive fullscreen. Only works with Direct3D 10/11." Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
+                    <TextBlock Margin="0,2,0,0" FontSize="12" Text="Enables using Alt + Enter to enter exclusive fullscreen. Only works with Direct3D." Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
                 </StackPanel>
             </ui:CardControl.Header>
             <ui:ToggleSwitch IsChecked="{Binding ExclusiveFullscreenEnabled, Mode=TwoWay}" />

--- a/Bloxstrap/Views/Pages/FastFlagsPage.xaml
+++ b/Bloxstrap/Views/Pages/FastFlagsPage.xaml
@@ -65,7 +65,7 @@
             <ui:CardControl.Header>
                 <StackPanel>
                     <TextBlock FontSize="14" Text="Enable exclusive fullscreen" />
-                    <TextBlock Margin="0,2,0,0" FontSize="12" Text="Enables using Alt + Enter to enter exclusive fullscreen. Only works with Direct3D 11." Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
+                    <TextBlock Margin="0,2,0,0" FontSize="12" Text="Enables using Alt + Enter to enter exclusive fullscreen. Only works with Direct3D 10/11." Foreground="{DynamicResource TextFillColorTertiaryBrush}" />
                 </StackPanel>
             </ui:CardControl.Header>
             <ui:ToggleSwitch IsChecked="{Binding ExclusiveFullscreenEnabled, Mode=TwoWay}" />


### PR DESCRIPTION
Saw a while back there was an option to actually force D3D10 and thought it'd be nice to add as an extra rendering mode for testing and *possibly* increase performance for older cards, it also supports True Alt+Enter so I've added a check to see if either D3D11 or D3D10 is enabled. I also removed the last remnant comment mentioning ReShade.

P.S: I don't actually have a card that is that ancient to get D3D10 forced on Roblox (your card has to be *like very very ancient* to get D3D10.0)

Here's a screenshot of the GPU Renderer showing as D3D10.0:
![image](https://user-images.githubusercontent.com/64731916/236657127-5305ff87-9887-4d0b-80a0-8f0fa916254e.png)
