### PR TITLE
Handle error when channel is not available to user

### DIFF
--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -237,9 +237,24 @@ namespace Bloxstrap
                 // Janky fix for error 401 ~25/10/2023
                 if (ex.ResponseMessage.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    App.Logger.WriteLine(LOG_IDENT, $"Setting channel to {RobloxDeployment.DefaultChannel} because channel {App.Settings.Prop.Channel} is unavailable to the user.");
-                    Controls.ShowMessageBox(
-                        $"Release channel {App.Settings.Prop.Channel} is not available to you. It has been reset to {RobloxDeployment.DefaultChannel}.", MessageBoxImage.Information);
+                    App.Logger.WriteLine(LOG_IDENT, $"Channel {App.Settings.Prop.Channel} is unavailable to the user.");
+                    if (App.Settings.Prop.ChannelChangeMode == ChannelChangeMode.Automatic)
+                        Controls.ShowMessageBox($"Release channel {App.Settings.Prop.Channel} is not available to you. It has been reset to {RobloxDeployment.DefaultChannel}.", MessageBoxImage.Information);
+                    else
+                    {
+                        MessageBoxResult channelChangeResult = Controls.ShowMessageBox(
+                            $"Release channel {App.Settings.Prop.Channel} is not available to you. Would you like to reset to {RobloxDeployment.DefaultChannel}?",
+                            MessageBoxImage.Warning,
+                            MessageBoxButton.YesNo);
+
+                        if (channelChangeResult != MessageBoxResult.Yes)
+                        {
+                            Controls.ShowMessageBox($"Client cannot be launched as you are enrolled into an unavailable release channel and refused to reset.", MessageBoxImage.Error);
+                            App.Logger.WriteLine(LOG_IDENT, $"User refused to reset channel. Aborting.");
+                            App.Terminate(ErrorCode.ERROR_CANCELLED);
+                        }
+                    }
+                    App.Logger.WriteLine(LOG_IDENT, $"Resetting release channel to {RobloxDeployment.DefaultChannel} as {App.Settings.Prop.Channel} is unavailable to the user.");
                 }
 
                 App.Settings.Prop.Channel = RobloxDeployment.DefaultChannel;

--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -229,10 +229,19 @@ namespace Bloxstrap
             }
             catch (HttpResponseException ex)
             {
-                if (ex.ResponseMessage.StatusCode != HttpStatusCode.NotFound)
+                if (ex.ResponseMessage.StatusCode != HttpStatusCode.NotFound && ex.ResponseMessage.StatusCode != HttpStatusCode.Unauthorized)
                     throw;
 
-                App.Logger.WriteLine(LOG_IDENT, $"Reverting enrolled channel to {RobloxDeployment.DefaultChannel} because a WindowsPlayer build does not exist for {App.Settings.Prop.Channel}");
+                if (ex.ResponseMessage.StatusCode == HttpStatusCode.NotFound)
+                    App.Logger.WriteLine(LOG_IDENT, $"Reverting enrolled channel to {RobloxDeployment.DefaultChannel} because a WindowsPlayer build does not exist for {App.Settings.Prop.Channel}");
+                // Janky fix for error 401 ~25/10/2023
+                if (ex.ResponseMessage.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    App.Logger.WriteLine(LOG_IDENT, $"Setting channel to {RobloxDeployment.DefaultChannel} because channel {App.Settings.Prop.Channel} is unavailable to the user.");
+                    Controls.ShowMessageBox(
+                        $"Release channel {App.Settings.Prop.Channel} is not available to you. It has been reset to {RobloxDeployment.DefaultChannel}.", MessageBoxImage.Information);
+                }
+
                 App.Settings.Prop.Channel = RobloxDeployment.DefaultChannel;
                 clientVersion = await RobloxDeployment.GetInfo(App.Settings.Prop.Channel);
             }

--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -229,18 +229,15 @@ namespace Bloxstrap
             }
             catch (HttpResponseException ex)
             {
-                if (ex.ResponseMessage.StatusCode != HttpStatusCode.NotFound && ex.ResponseMessage.StatusCode != HttpStatusCode.Unauthorized)
-                    throw;
-
+                // If channel does not exist
                 if (ex.ResponseMessage.StatusCode == HttpStatusCode.NotFound)
                     App.Logger.WriteLine(LOG_IDENT, $"Reverting enrolled channel to {RobloxDeployment.DefaultChannel} because a WindowsPlayer build does not exist for {App.Settings.Prop.Channel}");
-                // Janky fix for error 401 ~25/10/2023
-                if (ex.ResponseMessage.StatusCode == HttpStatusCode.Unauthorized)
+                // If channel is not available to the user (private/internal release channel)
+                else if (ex.ResponseMessage.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     App.Logger.WriteLine(LOG_IDENT, $"Channel {App.Settings.Prop.Channel} is unavailable to the user.");
-                    if (App.Settings.Prop.ChannelChangeMode == ChannelChangeMode.Automatic)
-                        Controls.ShowMessageBox($"Release channel {App.Settings.Prop.Channel} is not available to you. It has been reset to {RobloxDeployment.DefaultChannel}.", MessageBoxImage.Information);
-                    else
+                    // Only prompt if user has channel switching mode set to something other than Automatic.
+                    if (App.Settings.Prop.ChannelChangeMode != ChannelChangeMode.Automatic)
                     {
                         MessageBoxResult channelChangeResult = Controls.ShowMessageBox(
                             $"Release channel {App.Settings.Prop.Channel} is not available to you. Would you like to reset to {RobloxDeployment.DefaultChannel}?",
@@ -256,6 +253,7 @@ namespace Bloxstrap
                     }
                     App.Logger.WriteLine(LOG_IDENT, $"Resetting release channel to {RobloxDeployment.DefaultChannel} as {App.Settings.Prop.Channel} is unavailable to the user.");
                 }
+                else throw;
 
                 App.Settings.Prop.Channel = RobloxDeployment.DefaultChannel;
                 clientVersion = await RobloxDeployment.GetInfo(App.Settings.Prop.Channel);


### PR DESCRIPTION
This PR handles the 401 error when the user is not allowed to install from a particular release channel.  This should help with the people who are still on the `zlive` channel.