### PR TITLE
Fix image quality on certain UI images

### DIFF
--- a/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml
+++ b/Bloxstrap/UI/Elements/Bootstrapper/FluentDialog.xaml
@@ -30,11 +30,7 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <Border Grid.Column="0" Margin="0,12,0,0" Width="48" Height="48" VerticalAlignment="Top">
-                <Border.Background>
-                    <ImageBrush ImageSource="{Binding Icon, Mode=OneWay}" RenderOptions.BitmapScalingMode="HighQuality" />
-                </Border.Background>
-            </Border>
+            <Image Grid.Column="0" Margin="0,12,0,0" Width="48" Height="48" VerticalAlignment="Top" Source="{Binding Icon, Mode=OneWay}" RenderOptions.BitmapScalingMode="HighQuality" />
             <StackPanel Grid.Column="1">
                 <TextBlock Margin="16,8,0,0" FontSize="20" Text="{Binding Message, Mode=OneWay}" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
                 <ProgressBar Margin="16,16,0,16" IsIndeterminate="{Binding ProgressIndeterminate, Mode=OneWay}" Maximum="{Binding ProgressMaximum, Mode=OneWay}" Value="{Binding ProgressValue, Mode=OneWay}" />

--- a/Bloxstrap/UI/Elements/Menu/Pages/AboutPage.xaml
+++ b/Bloxstrap/UI/Elements/Menu/Pages/AboutPage.xaml
@@ -18,11 +18,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Border Grid.Column="0" Width="60" Height="60" VerticalAlignment="Center">
-                <Border.Background>
-                    <ImageBrush ImageSource="pack://application:,,,/Bloxstrap.ico" />
-                </Border.Background>
-            </Border>
+            <Image Grid.Column="0" Width="60" Height="60" VerticalAlignment="Center" Source="pack://application:,,,/Bloxstrap.ico" RenderOptions.BitmapScalingMode="HighQuality" />
             <StackPanel Grid.Column="1" Margin="12,0,0,0" VerticalAlignment="Center">
                 <Grid>
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
ImageBrushes are horrible. Please never use them ever again.

Before (ImageBrush):
![before](https://github.com/pizzaboxer/bloxstrap/assets/97983689/299db270-8941-4fca-afec-77125c2252f2)

After (Image):
![after](https://github.com/pizzaboxer/bloxstrap/assets/97983689/c3ed2c27-7331-4592-8107-84fdf617e39b)
