### PR TITLE
Rename Fluent Progress Aero to Glass

### DIFF
--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -840,7 +840,7 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fluent Progress (Aero).
+        ///   Looks up a localized string similar to Fluent Progress (Glass).
         /// </summary>
         public static string Enums_BootstrapperStyle_ProgressFluentAeroDialog {
             get {

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -383,7 +383,7 @@ Your ReShade configuration files will still be saved, and you can locate them by
     <value>Progress (~2014)</value>
   </data>
   <data name="Enums.BootstrapperStyle.ProgressFluentAeroDialog" xml:space="preserve">
-    <value>Fluent Progress (Aero)</value>
+    <value>Fluent Progress (Glass)</value>
   </data>
   <data name="Enums.BootstrapperStyle.ProgressFluentDialog" xml:space="preserve">
     <value>Fluent Progress</value>


### PR DESCRIPTION
I likely forgot to push this change months ago. It's meant to be called "Glass" instead of "Aero".