### PR TITLE
fix uninstall reg key for roblox

### DIFF
--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Forms;
 
 using Microsoft.Win32;
@@ -725,7 +725,7 @@ namespace Bloxstrap
             {
                 // revert launch uri handler to stock bootstrapper
 
-                string bootstrapperLocation = (string?)bootstrapperKey.GetValue("InstallLocation") + "RobloxPlayerLauncher.exe";
+                string bootstrapperLocation = (string?)bootstrapperKey.GetValue("InstallLocation") + "\\RobloxPlayerLauncher.exe";
 
                 ProtocolHandler.Register("roblox", "Roblox", bootstrapperLocation);
                 ProtocolHandler.Register("roblox-player", "Roblox", bootstrapperLocation);


### PR DESCRIPTION
When you uninstall Bloxstrap, the registry key to open Roblox from the website is incorrect. This PR fixes it.
before
![image](https://github.com/pizzaboxer/bloxstrap/assets/98912029/470fd155-c0d8-43b0-8e9f-a15cdffa591d)
after
![image](https://github.com/pizzaboxer/bloxstrap/assets/98912029/3595b64d-d1c0-481f-8ace-45630d348cdb)
