### PR TITLE
Add launch confirmation setting

### DIFF
--- a/Bloxstrap/App.xaml.cs
+++ b/Bloxstrap/App.xaml.cs
@@ -204,10 +204,10 @@ namespace Bloxstrap
             if (!IsFirstRun)
                 ShouldSaveConfigs = true;
             
-            if (Mutex.TryOpenExisting("ROBLOX_singletonMutex", out var _))
+            if (App.Settings.Prop.LaunchConfirmation && Mutex.TryOpenExisting("ROBLOX_singletonMutex", out var _))
             {
                 var result = Frontend.ShowMessageBox(
-                    "Roblox is currently running, and launching another instance will close it. Are you sure you want to continue launching?", 
+                    Bloxstrap.Resources.Strings.Bootstrapper_LaunchConfirmation, 
                     MessageBoxImage.Warning, 
                     MessageBoxButton.YesNo
                 );

--- a/Bloxstrap/Models/Settings.cs
+++ b/Bloxstrap/Models/Settings.cs
@@ -12,6 +12,7 @@ namespace Bloxstrap.Models
         public Theme Theme { get; set; } = Theme.Default;
         public bool CheckForUpdates { get; set; } = true;
         public bool CreateDesktopIcon { get; set; } = true;
+        public bool LaunchConfirmation { get; set; } = true;
 
         // channel configuration
         public string Channel { get; set; } = RobloxDeployment.DefaultChannel;

--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -144,6 +144,15 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Roblox is currently running, and launching another instance will close it. Are you sure you want to continue launching?.
+        /// </summary>
+        public static string Bootstrapper_LaunchConfirmation {
+            get {
+                return ResourceManager.GetString("Bootstrapper.LaunchConfirmation", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Bloxstrap does not have enough disk space to download and install Roblox. Please free up some disk space and try again..
         /// </summary>
         public static string Bootstrapper_NotEnoughSpace {
@@ -1676,6 +1685,24 @@ namespace Bloxstrap.Resources {
         public static string Menu_Behaviour_ForceRobloxReinstall_Title {
             get {
                 return ResourceManager.GetString("Menu.Behaviour.ForceRobloxReinstall.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A confirmation window for launching will be displayed if Roblox is already running..
+        /// </summary>
+        public static string Menu_Behaviour_LaunchConfirmation_Description {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.LaunchConfirmation.Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch confirmation.
+        /// </summary>
+        public static string Menu_Behaviour_LaunchConfirmation_Title {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.LaunchConfirmation.Title", resourceCulture);
             }
         }
         

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -146,6 +146,9 @@
 
 Your ReShade configuration files will still be saved, and you can locate them by opening the folder where Bloxstrap is installed to, and navigating to the Integrations folder. You can choose to delete these if you want.</value>
   </data>
+  <data name="Bootstrapper.LaunchConfirmation" xml:space="preserve">
+    <value>Roblox is currently running, and launching another instance will close it. Are you sure you want to continue launching?</value>
+  </data>
   <data name="Bootstrapper.NotEnoughSpace" xml:space="preserve">
     <value>Bloxstrap does not have enough disk space to download and install Roblox. Please free up some disk space and try again.</value>
   </data>
@@ -664,6 +667,12 @@ Would you like to upgrade your currently installed version?</value>
   </data>
   <data name="Menu.Behaviour.ForceRobloxReinstall.Title" xml:space="preserve">
     <value>Force Roblox reinstallation</value>
+  </data>
+  <data name="Menu.Behaviour.LaunchConfirmation.Description" xml:space="preserve">
+    <value>A confirmation window for launching will be displayed if Roblox is already running.</value>
+  </data>
+  <data name="Menu.Behaviour.LaunchConfirmation.Title" xml:space="preserve">
+    <value>Launch confirmation</value>
   </data>
   <data name="Menu.Behaviour.Title" xml:space="preserve">
     <value>Behaviour</value>

--- a/Bloxstrap/UI/Elements/Menu/Pages/BehaviourPage.xaml
+++ b/Bloxstrap/UI/Elements/Menu/Pages/BehaviourPage.xaml
@@ -43,5 +43,20 @@
             </controls:OptionControl.Style>
             <ui:ToggleSwitch IsChecked="{Binding ForceRobloxReinstallation, Mode=TwoWay}" />
         </controls:OptionControl>
+
+        <controls:OptionControl 
+            Header="{x:Static resources:Strings.Menu_Behaviour_LaunchConfirmation_Title}"
+            Description="{x:Static resources:Strings.Menu_Behaviour_LaunchConfirmation_Description}">
+            <controls:OptionControl.Style>
+                <Style TargetType="{x:Type controls:OptionControl}">
+                    <d:Style.Triggers>
+                        <DataTrigger Binding="{Binding LaunchConfirmation, Mode=OneTime}" Value="True">
+                            <Setter Property="IsEnabled" Value="True" />
+                        </DataTrigger>
+                    </d:Style.Triggers>
+                </Style>
+            </controls:OptionControl.Style>
+            <ui:ToggleSwitch IsChecked="{Binding LaunchConfirmation, Mode=TwoWay}" />
+        </controls:OptionControl>
     </StackPanel>
 </ui:UiPage>

--- a/Bloxstrap/UI/Elements/Menu/Pages/BehaviourPage.xaml
+++ b/Bloxstrap/UI/Elements/Menu/Pages/BehaviourPage.xaml
@@ -47,15 +47,6 @@
         <controls:OptionControl 
             Header="{x:Static resources:Strings.Menu_Behaviour_LaunchConfirmation_Title}"
             Description="{x:Static resources:Strings.Menu_Behaviour_LaunchConfirmation_Description}">
-            <controls:OptionControl.Style>
-                <Style TargetType="{x:Type controls:OptionControl}">
-                    <d:Style.Triggers>
-                        <DataTrigger Binding="{Binding LaunchConfirmation, Mode=OneTime}" Value="True">
-                            <Setter Property="IsEnabled" Value="True" />
-                        </DataTrigger>
-                    </d:Style.Triggers>
-                </Style>
-            </controls:OptionControl.Style>
             <ui:ToggleSwitch IsChecked="{Binding LaunchConfirmation, Mode=TwoWay}" />
         </controls:OptionControl>
     </StackPanel>

--- a/Bloxstrap/UI/ViewModels/Menu/BehaviourViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Menu/BehaviourViewModel.cs
@@ -38,5 +38,11 @@
                 }
             }
         }
+
+        public bool LaunchConfirmation
+        {
+            get => App.Settings.Prop.LaunchConfirmation;
+            set => App.Settings.Prop.LaunchConfirmation = value;
+        }
     }
 }


### PR DESCRIPTION
This PR adds a setting to toggle the new feature introduced in v2.6.0 which displays a confirmation window asking if you want to launch a Roblox instance even though one is already running. This PR also adds strings for the feature.

Closes #2060 