### PR TITLE
Fix ManageCustomFont crash

### DIFF
--- a/Bloxstrap/UI/ViewModels/Menu/ModsViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Menu/ModsViewModel.cs
@@ -46,7 +46,7 @@ namespace Bloxstrap.UI.ViewModels.Menu
 
                 string type = dialog.FileName.Substring(dialog.FileName.Length-3, 3).ToLowerInvariant();
 
-                if (!File.ReadAllBytes(dialog.FileName).Take(4).SequenceEqual(FontHeaders[type]))
+                if (!FontHeaders.ContainsKey(type) || !File.ReadAllBytes(dialog.FileName).Take(4).SequenceEqual(FontHeaders[type]))
                 {
                     Frontend.ShowMessageBox(Resources.Strings.Menu_Mods_Misc_CustomFont_Invalid, MessageBoxImage.Error);
                     return;


### PR DESCRIPTION
Even with the OpenFileDialog filter, people can input their own files. Selecting a file with a file extension not present in the FontHeaders dictionary results in an exception.