### PR TITLE
Correct OpenFileDialog filter

### DIFF
--- a/Bloxstrap/UI/ViewModels/Menu/AppearanceViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Menu/AppearanceViewModel.cs
@@ -35,7 +35,7 @@ namespace Bloxstrap.UI.ViewModels.Menu
         {
             var dialog = new OpenFileDialog
             {
-                Filter = $"{Resources.Strings.Menu_IconFiles}|*.ico|{Resources.Strings.Menu_AllFiles}|*.*"
+                Filter = $"{Resources.Strings.Menu_IconFiles}|*.ico"
             };
 
             if (dialog.ShowDialog() != true)


### PR DESCRIPTION
In the menu for Bootstrapper appearance, in the icon customization section, there's text which states that the selected file must be a .ico file. This PR removes a part of the filter which allows any file to be selected.