### PR TITLE
Fix Turkish translation link markdown

### DIFF
--- a/Bloxstrap/Resources/Strings.tr.resx
+++ b/Bloxstrap/Resources/Strings.tr.resx
@@ -683,7 +683,7 @@ Bunu, diğer insanlar tarafından yapılan ve performansı artırmayı vaat eden
     <value>Kare hızı limiti (FPS)</value>
   </data>
   <data name="Menu.FastFlags.Presets.HideGuis.Description" xml:space="preserve">
-    <value>Klavye kısayolları]({0}) ile değiştirilir. Yalnızca [Bloxstrap grubu]({1}) içindeyseniz çalışır.</value>
+    <value>[Klavye kısayolları]({0}) ile değiştirilir. Yalnızca [Bloxstrap grubu]({1}) içindeyseniz çalışır.</value>
   </data>
   <data name="Menu.FastFlags.Presets.HideGuis.Title" xml:space="preserve">
     <value>GUI'leri gizleme özelliğini etkinleştir</value>


### PR DESCRIPTION
This pull request fixes the link markdown issue in "Klavye kısayolları" for Turkish translation.
![image](https://github.com/pizzaboxer/bloxstrap/assets/68702247/68a01b5f-9671-4c89-92d7-3dda350400aa)