### PR TITLE
Custom integration name autofill

### DIFF
--- a/Bloxstrap/UI/Elements/Settings/Pages/IntegrationsPage.xaml
+++ b/Bloxstrap/UI/Elements/Settings/Pages/IntegrationsPage.xaml
@@ -89,7 +89,7 @@
                     </Style>
                 </StackPanel.Style>
                 <TextBlock Text="{x:Static resources:Strings.Common_Name}" Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
-                <ui:TextBox Margin="0,4,0,0" Text="{Binding SelectedCustomIntegration.Name}" />
+                <ui:TextBox Margin="0,4,0,0" Text="{Binding SelectedCustomIntegration.Name, UpdateSourceTrigger=PropertyChanged}" />
                 <TextBlock Margin="0,8,0,0" Text="{x:Static resources:Strings.Menu_Integrations_Custom_AppLocation}" Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                 <Grid Margin="0,4,0,0">
                     <Grid.ColumnDefinitions>

--- a/Bloxstrap/UI/ViewModels/Settings/IntegrationsViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/IntegrationsViewModel.cs
@@ -57,6 +57,7 @@ namespace Bloxstrap.UI.ViewModels.Settings
             if (dialog.ShowDialog() != true)
                 return;
 
+            SelectedCustomIntegration.Name = dialog.SafeFileName;
             SelectedCustomIntegration.Location = dialog.FileName;
             OnPropertyChanged(nameof(SelectedCustomIntegration));
         }


### PR DESCRIPTION
This pull request adds a QOL change which automatically sets the name of a new custom integration to the selected file's name. It also updates an integration's name while the user is typing in the text box.