### PR TITLE
Add error handling to IconEx::GetImageSource

### DIFF
--- a/Bloxstrap/Extensions/IconEx.cs
+++ b/Bloxstrap/Extensions/IconEx.cs
@@ -10,9 +10,22 @@ namespace Bloxstrap.Extensions
 
         public static ImageSource GetImageSource(this Icon icon)
         {
-            using MemoryStream stream = new();
-            icon.Save(stream);
-            return BitmapFrame.Create(stream, BitmapCreateOptions.None, BitmapCacheOption.OnLoad);
+            const string LOG_IDENT = "IconEx::GetImageSource";
+
+            try
+            {
+                using MemoryStream stream = new();
+                icon.Save(stream);
+                return BitmapFrame.Create(stream, BitmapCreateOptions.None, BitmapCacheOption.OnLoad);
+            }
+            catch (Exception ex)
+            {
+                App.Logger.WriteLine(LOG_IDENT, "Failed to get ImageSource");
+                App.Logger.WriteException(LOG_IDENT, ex);
+
+                // return fallback image
+                return Utilities.GetEmptyBitmap();
+            }
         }
     }
 }

--- a/Bloxstrap/Utilities.cs
+++ b/Bloxstrap/Utilities.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Windows.Media.Imaging;
+using System.Windows.Media;
 
 namespace Bloxstrap
 {
@@ -80,6 +82,18 @@ namespace Bloxstrap
                 App.Logger.WriteException(LOG_IDENT, ex);
                 return Array.Empty<Process>(); // can we retry?
             }
+        }
+
+        private static BitmapSource? _emptyBitmap;
+        public static BitmapSource GetEmptyBitmap()
+        {
+            return _emptyBitmap ??= CreateEmptyBitmap();
+        }
+
+        // https://stackoverflow.com/a/50316845
+        public static BitmapSource CreateEmptyBitmap()
+        {
+            return BitmapSource.Create(1, 1, 1, 1, PixelFormats.BlackWhite, null, new byte[] { 0 }, 1);
         }
     }
 }


### PR DESCRIPTION
Remember to update the projects thing on merge.
Defaults to a black pixel image upon failure.