### PR TITLE
Fix RPC removing account image when "Show Roblox Account" is active

### DIFF
--- a/Bloxstrap/Integrations/DiscordRichPresence.cs
+++ b/Bloxstrap/Integrations/DiscordRichPresence.cs
@@ -226,7 +226,8 @@ namespace Bloxstrap.Integrations
             ulong? smallImgFetch = null;
             ulong? largeImgFetch = null;
 
-            if (presenceData.SmallImage is not null)
+            // only set small image if account display is disabled, doesnt make sense to override it if it is true
+            if (presenceData.SmallImage is not null && !App.Settings.Prop.ShowAccountOnRichPresence)
             {
                 if (presenceData.SmallImage.Clear)
                 {


### PR DESCRIPTION
This small addition should stop games from being able to reset/change/clear the small image in the Discord RPC when the "Show Roblox Account" feature is enabled.

Before:
<img width="269" height="111" alt="Discord_ArGQ6HqEzl" src="https://github.com/user-attachments/assets/8337e958-ea07-49b6-a520-419c809f1520" />

After:
<img width="270" height="112" alt="Discord_TmGO0sYsQe" src="https://github.com/user-attachments/assets/d3bfc3f6-a40b-49e5-a3f0-e69446f7d7fd" />
