### PR TITLE
Improve log file deletion

### DIFF
--- a/Bloxstrap/Logger.cs
+++ b/Bloxstrap/Logger.cs
@@ -79,7 +79,13 @@
             // delete older logs if there are more than 15
             if (Paths.Initialized && Directory.Exists(Paths.Logs))
             {
-                foreach (FileInfo log in new DirectoryInfo(Paths.Logs).GetFiles().OrderByDescending(log => log.LastWriteTimeUtc).Skip(15))
+                const int maxLogs = 15;
+                FileInfo[] logs = new DirectoryInfo(Paths.Logs).GetFiles();
+
+                if (logs.Length <= maxLogs)
+                    return;
+
+                foreach (FileInfo log in logs.OrderByDescending(log => log.LastWriteTimeUtc).Skip(maxLogs))
                 {
                     WriteLine(LOG_IDENT, $"Cleaning up old log file '{log.Name}'");
 


### PR DESCRIPTION
Deletes old log files when there are more than 15.
One can easily rack up hundreds of log files in a week, so why not just put a limit on it?