### PR TITLE
Fix activity watcher when using RbxTransport

### DIFF
--- a/Bloxstrap/Integrations/ActivityWatcher.cs
+++ b/Bloxstrap/Integrations/ActivityWatcher.cs
@@ -14,7 +14,7 @@
         private const string GameJoiningReservedServerEntry  = "[FLog::GameJoinUtil] GameJoinUtil::initiateTeleportToReservedServer";
         private const string GameJoiningUniverseEntry        = "[FLog::GameJoinLoadTime] Report game_join_loadtime:";
         private const string GameJoiningUDMUXEntry           = "[FLog::Network] UDMUX Address = ";
-        private const string GameJoinedEntry                 = "[FLog::Network] serverId:";
+        private const string GameJoinedEntry                 = "[FLog::Network] Replicator created: ";
         private const string GameDisconnectedEntry           = "[FLog::Network] Time to disconnect replication data:";
         private const string GameLeavingEntry                = "[FLog::SingleSurfaceApp] leaveUGCGameInternal";
 
@@ -269,15 +269,6 @@
                 }
                 else if (logMessage.StartsWith(GameJoinedEntry))
                 {
-                    Match match = Regex.Match(logMessage, GameJoinedEntryPattern);
-
-                    if (match.Groups.Count != 2 || match.Groups[1].Value != Data.MachineAddress)
-                    {
-                        App.Logger.WriteLine(LOG_IDENT, $"Failed to assert format for game joined entry");
-                        App.Logger.WriteLine(LOG_IDENT, logMessage);
-                        return;
-                    }
-
                     App.Logger.WriteLine(LOG_IDENT, $"Joined Game ({Data})");
 
                     InGame = true;


### PR DESCRIPTION
Read log entry changed to future proof in-case the obsolete serverId log is removed

Fixes #6369