### PR TITLE
Add MediaElement tag for custom bootstrappers

### DIFF
--- a/Bloxstrap/Resources/CustomBootstrapperSchema.json
+++ b/Bloxstrap/Resources/CustomBootstrapperSchema.json
@@ -134,7 +134,8 @@
 				"Stretch": "Stretch",
 				"StretchDirection": "StretchDirection",
 				"Source": "Uri",
-				"Volume": "double"
+				"Volume": "double",
+				"Looped": "bool"
 			}
 		},
 		"Grid": {

--- a/Bloxstrap/Resources/CustomBootstrapperSchema.json
+++ b/Bloxstrap/Resources/CustomBootstrapperSchema.json
@@ -124,7 +124,17 @@
 				"StretchDirection": "StretchDirection",
 				"Source": "ImageSource",
 				"IsAnimated": "bool",
-				"RepeatBehavior":  "RepeatBehavior"
+				"RepeatBehavior": "RepeatBehavior"
+			}
+		},
+		"MediaElement": {
+			"SuperClass": "FrameworkElement",
+			"IsCreatable": true,
+			"Attributes": {
+				"Stretch": "Stretch",
+				"StretchDirection": "StretchDirection",
+				"Source": "Uri",
+				"Volume": "double"
 			}
 		},
 		"Grid": {
@@ -322,6 +332,7 @@
 		"Rect": {},
 		"Point": {},
 		"CornerRadius": {},
+		"Uri": {},
 		"Brush": { "CanHaveElement": true },
 		"Color": {},
 		"ImageSource": {},

--- a/Bloxstrap/Resources/CustomBootstrapperSchema.json
+++ b/Bloxstrap/Resources/CustomBootstrapperSchema.json
@@ -134,7 +134,6 @@
 				"Stretch": "Stretch",
 				"StretchDirection": "StretchDirection",
 				"Source": "Uri",
-				"Volume": "double",
 				"Looped": "bool"
 			}
 		},

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Creator.cs
@@ -30,6 +30,7 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             ["TextBlock"] = HandleXmlElement_TextBlock,
             ["MarkdownTextBlock"] = HandleXmlElement_MarkdownTextBlock,
             ["Image"] = HandleXmlElement_Image,
+            ["MediaElement"] = HandleXmlElement_MediaElement,
             ["Grid"] = HandleXmlElement_Grid,
             ["StackPanel"] = HandleXmlElement_StackPanel,
             ["Border"] = HandleXmlElement_Border,

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
@@ -638,6 +638,35 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             return image;
         }
 
+        private static UIElement HandleXmlElement_MediaElement(CustomDialog dialog, XElement xmlElement)
+        {
+            var media = new MediaElement();
+            HandleXmlElement_FrameworkElement(dialog, media, xmlElement);
+
+            RenderOptions.SetBitmapScalingMode(media, BitmapScalingMode.HighQuality); // i think letting this be modifiable would be funny
+
+            // should behaviour be modifiable? (except unloadedbehavior ig)
+            media.LoadedBehavior = MediaState.Play;
+            media.UnloadedBehavior = MediaState.Close;
+
+            media.Volume = ParseXmlAttribute<double>(xmlElement, "Volume", 1);
+
+            media.Stretch = ParseXmlAttribute<Stretch>(xmlElement, "Stretch", Stretch.Uniform);
+            media.StretchDirection = ParseXmlAttribute<StretchDirection>(xmlElement, "StretchDirection", StretchDirection.Both);
+
+            media.Source = GetMediaSourceData(dialog, "Source", xmlElement);
+
+            if (ParseXmlAttribute<bool>(xmlElement, "Looped", true))
+            {
+                media.MediaEnded += (Sender, e) =>
+                {
+                    media.Position = TimeSpan.Zero;
+                };
+            }
+
+            return media;
+        }
+
         private static RowDefinition HandleXmlElement_RowDefinition(CustomDialog dialog, XElement xmlElement)
         {
             var rowDefinition = new RowDefinition();

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Elements.cs
@@ -643,20 +643,20 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             var media = new MediaElement();
             HandleXmlElement_FrameworkElement(dialog, media, xmlElement);
 
-            RenderOptions.SetBitmapScalingMode(media, BitmapScalingMode.HighQuality); // i think letting this be modifiable would be funny
+            RenderOptions.SetBitmapScalingMode(media, BitmapScalingMode.HighQuality);
 
             // should behaviour be modifiable? (except unloadedbehavior ig)
             media.LoadedBehavior = MediaState.Play;
             media.UnloadedBehavior = MediaState.Close;
 
-            media.Volume = ParseXmlAttribute<double>(xmlElement, "Volume", 1);
+            media.Volume = 0;
 
             media.Stretch = ParseXmlAttribute<Stretch>(xmlElement, "Stretch", Stretch.Uniform);
             media.StretchDirection = ParseXmlAttribute<StretchDirection>(xmlElement, "StretchDirection", StretchDirection.Both);
 
             media.Source = GetMediaSourceData(dialog, "Source", xmlElement);
 
-            if (ParseXmlAttribute<bool>(xmlElement, "Looped", true))
+            if (ParseXmlAttribute<bool>(xmlElement, "Looped", false))
             {
                 media.MediaEnded += (Sender, e) =>
                 {

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Utilities.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Utilities.cs
@@ -245,9 +245,7 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             if (result.Scheme != "file")
                 throw new CustomThemeException("CustomTheme.Errors.ElementAttributeBlacklistedUriScheme", xmlElement.Name, name, result.Scheme);
 
-            Uri uri = result;
-
-            return uri;
+            return result;
         }
 
         private static object? GetContentFromXElement(CustomDialog dialog, XElement xmlElement)

--- a/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Utilities.cs
+++ b/Bloxstrap/UI/Elements/Bootstrapper/CustomDialog.Utilities.cs
@@ -230,6 +230,26 @@ namespace Bloxstrap.UI.Elements.Bootstrapper
             return new GetImageSourceDataResult { Uri = result };
         }
 
+        private static Uri GetMediaSourceData(CustomDialog dialog, string name, XElement xmlElement)
+        {
+            string path = GetXmlAttribute(xmlElement, name);
+
+            path = GetFullPath(dialog, path)!;
+
+            if (!Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out Uri? result))
+                throw new CustomThemeException("CustomTheme.Errors.ElementAttributeParseError", xmlElement.Name, name, "Uri");
+
+            if (result == null)
+                throw new CustomThemeException("CustomTheme.Errors.ElementAttributeParseErrorNull", xmlElement.Name, name, "Uri");
+
+            if (result.Scheme != "file")
+                throw new CustomThemeException("CustomTheme.Errors.ElementAttributeBlacklistedUriScheme", xmlElement.Name, name, result.Scheme);
+
+            Uri uri = result;
+
+            return uri;
+        }
+
         private static object? GetContentFromXElement(CustomDialog dialog, XElement xmlElement)
         {
             var contentAttr = xmlElement.Attribute("Content");


### PR DESCRIPTION
Let's MediaElement be usable for custom bootstrappers. GIFs are great, but their quality sucks ass.

Below is a demonstration:

https://github.com/user-attachments/assets/aa67f166-0247-411f-992c-7cd2b5a10c45

Compatible media types:

**Video**: WMV, AVI, MPEG, and MP4 (H.264/AVC).

I have also added a custom attribute called "Looped", which lets users specify if they want said media element to loop or not.