### PR TITLE
Add a toggle for caching Roblox update packages

### DIFF
--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -1197,7 +1197,7 @@ namespace Bloxstrap
 
             if (!App.Settings.Prop.DebugDisableVersionPackageCleanup)
             {
-                if (App.Settings.Prop.CacheDownloads)
+                if (!App.Settings.Prop.DisableCachingDownloads)
                 {
                     foreach (string hash in cachedPackageHashes)
                     {

--- a/Bloxstrap/Bootstrapper.cs
+++ b/Bloxstrap/Bootstrapper.cs
@@ -1197,19 +1197,40 @@ namespace Bloxstrap
 
             if (!App.Settings.Prop.DebugDisableVersionPackageCleanup)
             {
-                foreach (string hash in cachedPackageHashes)
+                if (App.Settings.Prop.CacheDownloads)
                 {
-                    if (!allPackageHashes.Contains(hash))
+                    foreach (string hash in cachedPackageHashes)
                     {
-                        App.Logger.WriteLine(LOG_IDENT, $"Deleting unused package {hash}");
+                        if (!allPackageHashes.Contains(hash))
+                        {
+                            App.Logger.WriteLine(LOG_IDENT, $"Deleting unused package {hash}");
+
+                            try
+                            {
+                                File.Delete(Path.Combine(Paths.Downloads, hash));
+                            }
+                            catch (Exception ex)
+                            {
+                                App.Logger.WriteLine(LOG_IDENT, $"Failed to delete {hash}!");
+                                App.Logger.WriteException(LOG_IDENT, ex);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // its better to just delete all the files in downloads
+                    foreach (FileInfo pkg in new DirectoryInfo(Paths.Downloads).GetFiles())
+                    {
+                        App.Logger.WriteLine(LOG_IDENT, $"Cleaning up package '{pkg.Name}'");
 
                         try
                         {
-                            File.Delete(Path.Combine(Paths.Downloads, hash));
+                            pkg.Delete();
                         }
                         catch (Exception ex)
                         {
-                            App.Logger.WriteLine(LOG_IDENT, $"Failed to delete {hash}!");
+                            App.Logger.WriteLine(LOG_IDENT, "Failed to delete package!");
                             App.Logger.WriteException(LOG_IDENT, ex);
                         }
                     }

--- a/Bloxstrap/Models/Persistable/Settings.cs
+++ b/Bloxstrap/Models/Persistable/Settings.cs
@@ -19,6 +19,7 @@ namespace Bloxstrap.Models.Persistable
         public bool WPFSoftwareRender { get; set; } = false;
         public bool EnableAnalytics { get; set; } = true;
         public bool BackgroundUpdatesEnabled { get; set; } = false;
+        public bool CacheDownloads { get; set; } = true;
         public bool DebugDisableVersionPackageCleanup { get; set; } = false;
         public string? SelectedCustomTheme { get; set; } = null;
         public WebEnvironment WebEnvironment { get; set; } = WebEnvironment.Production;

--- a/Bloxstrap/Models/Persistable/Settings.cs
+++ b/Bloxstrap/Models/Persistable/Settings.cs
@@ -19,7 +19,7 @@ namespace Bloxstrap.Models.Persistable
         public bool WPFSoftwareRender { get; set; } = false;
         public bool EnableAnalytics { get; set; } = true;
         public bool BackgroundUpdatesEnabled { get; set; } = false;
-        public bool CacheDownloads { get; set; } = true;
+        public bool DisableCachingDownloads { get; set; } = false;
         public bool DebugDisableVersionPackageCleanup { get; set; } = false;
         public string? SelectedCustomTheme { get; set; } = null;
         public WebEnvironment WebEnvironment { get; set; } = WebEnvironment.Production;

--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -2537,24 +2537,6 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow Bloxstrap to keep Roblox update files downloaded to speed up future updates..
-        /// </summary>
-        public static string Menu_Behaviour_CacheDownloads_Description {
-            get {
-                return ResourceManager.GetString("Menu.Behaviour.CacheDownloads.Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cache Roblox update files.
-        /// </summary>
-        public static string Menu_Behaviour_CacheDownloads_Title {
-            get {
-                return ResourceManager.GetString("Menu.Behaviour.CacheDownloads.Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Prevent against closures of your existing game from accidentally launching another one..
         /// </summary>
         public static string Menu_Behaviour_ConfirmLaunches_Description {
@@ -2578,6 +2560,24 @@ namespace Bloxstrap.Resources {
         public static string Menu_Behaviour_Description {
             get {
                 return ResourceManager.GetString("Menu.Behaviour.Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prevents Bloxstrap from caching Roblox version update files. This will slow down updates..
+        /// </summary>
+        public static string Menu_Behaviour_DisableCachingDownloads_Description {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.DisableCachingDownloads.Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable caching Roblox update files.
+        /// </summary>
+        public static string Menu_Behaviour_DisableCachingDownloads_Title {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.DisableCachingDownloads.Title", resourceCulture);
             }
         }
         

--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -2537,6 +2537,24 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Bloxstrap to cache Roblox update files to speed up updating Roblox..
+        /// </summary>
+        public static string Menu_Behaviour_CacheDownloads_Description {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.CacheDownloads.Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cache Roblox update files.
+        /// </summary>
+        public static string Menu_Behaviour_CacheDownloads_Title {
+            get {
+                return ResourceManager.GetString("Menu.Behaviour.CacheDownloads.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prevent against closures of your existing game from accidentally launching another one..
         /// </summary>
         public static string Menu_Behaviour_ConfirmLaunches_Description {

--- a/Bloxstrap/Resources/Strings.Designer.cs
+++ b/Bloxstrap/Resources/Strings.Designer.cs
@@ -2537,7 +2537,7 @@ namespace Bloxstrap.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow Bloxstrap to cache Roblox update files to speed up updating Roblox..
+        ///   Looks up a localized string similar to Allow Bloxstrap to keep Roblox update files downloaded to speed up future updates..
         /// </summary>
         public static string Menu_Behaviour_CacheDownloads_Description {
             get {

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -1386,10 +1386,10 @@ Defaulting to {1}.</value>
   <data name="Menu.FastFlagEditor.AllowlistInformation" xml:space="preserve">
     <value>Due to the [Fast Flag allowlist update]({0}), most custom Fast Flags will have no effect on the Roblox player.</value>
   </data>
-  <data name="Menu.Behaviour.CacheDownloads.Description" xml:space="preserve">
-    <value>Allow Bloxstrap to keep Roblox update files downloaded to speed up future updates.</value>
+  <data name="Menu.Behaviour.DisableCachingDownloads.Description" xml:space="preserve">
+    <value>Prevents Bloxstrap from caching Roblox version update files. This will slow down updates.</value>
   </data>
-  <data name="Menu.Behaviour.CacheDownloads.Title" xml:space="preserve">
-    <value>Cache Roblox update files</value>
+  <data name="Menu.Behaviour.DisableCachingDownloads.Title" xml:space="preserve">
+    <value>Disable caching Roblox update files</value>
   </data>
 </root>

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -1386,4 +1386,10 @@ Defaulting to {1}.</value>
   <data name="Menu.FastFlagEditor.AllowlistInformation" xml:space="preserve">
     <value>Due to the [Fast Flag allowlist update]({0}), most custom Fast Flags will have no effect on the Roblox player.</value>
   </data>
+  <data name="Menu.Behaviour.CacheDownloads.Description" xml:space="preserve">
+    <value>Allow Bloxstrap to cache Roblox update files to speed up updating Roblox.</value>
+  </data>
+  <data name="Menu.Behaviour.CacheDownloads.Title" xml:space="preserve">
+    <value>Cache Roblox update files</value>
+  </data>
 </root>

--- a/Bloxstrap/Resources/Strings.resx
+++ b/Bloxstrap/Resources/Strings.resx
@@ -1387,7 +1387,7 @@ Defaulting to {1}.</value>
     <value>Due to the [Fast Flag allowlist update]({0}), most custom Fast Flags will have no effect on the Roblox player.</value>
   </data>
   <data name="Menu.Behaviour.CacheDownloads.Description" xml:space="preserve">
-    <value>Allow Bloxstrap to cache Roblox update files to speed up updating Roblox.</value>
+    <value>Allow Bloxstrap to keep Roblox update files downloaded to speed up future updates.</value>
   </data>
   <data name="Menu.Behaviour.CacheDownloads.Title" xml:space="preserve">
     <value>Cache Roblox update files</value>

--- a/Bloxstrap/UI/Elements/Settings/Pages/BootstrapperPage.xaml
+++ b/Bloxstrap/UI/Elements/Settings/Pages/BootstrapperPage.xaml
@@ -30,6 +30,12 @@
         </controls:OptionControl>
 
         <controls:OptionControl 
+            Header="{x:Static resources:Strings.Menu_Behaviour_CacheDownloads_Title}"
+            Description="{x:Static resources:Strings.Menu_Behaviour_CacheDownloads_Description}">
+            <ui:ToggleSwitch IsChecked="{Binding CacheDownloads, Mode=TwoWay}" />
+        </controls:OptionControl>
+
+        <controls:OptionControl 
             Header="{x:Static resources:Strings.Menu_Behaviour_ForceRobloxReinstall_Title}"
             Description="{x:Static resources:Strings.Menu_Behaviour_ForceRobloxReinstall_Description}">
             <controls:OptionControl.Style>

--- a/Bloxstrap/UI/Elements/Settings/Pages/BootstrapperPage.xaml
+++ b/Bloxstrap/UI/Elements/Settings/Pages/BootstrapperPage.xaml
@@ -30,9 +30,9 @@
         </controls:OptionControl>
 
         <controls:OptionControl 
-            Header="{x:Static resources:Strings.Menu_Behaviour_CacheDownloads_Title}"
-            Description="{x:Static resources:Strings.Menu_Behaviour_CacheDownloads_Description}">
-            <ui:ToggleSwitch IsChecked="{Binding CacheDownloads, Mode=TwoWay}" />
+            Header="{x:Static resources:Strings.Menu_Behaviour_DisableCachingDownloads_Title}"
+            Description="{x:Static resources:Strings.Menu_Behaviour_DisableCachingDownloads_Description}">
+            <ui:ToggleSwitch IsChecked="{Binding DisableCachingDownloads, Mode=TwoWay}" />
         </controls:OptionControl>
 
         <controls:OptionControl 

--- a/Bloxstrap/UI/ViewModels/Settings/BehaviourViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/BehaviourViewModel.cs
@@ -14,6 +14,12 @@
             set => App.Settings.Prop.BackgroundUpdatesEnabled = value;
         }
 
+        public bool CacheDownloads
+        {
+            get => App.Settings.Prop.CacheDownloads;
+            set => App.Settings.Prop.CacheDownloads = value;
+        }
+
         public bool IsRobloxInstallationMissing => !App.IsPlayerInstalled && !App.IsStudioInstalled;
 
         public bool ForceRobloxReinstallation

--- a/Bloxstrap/UI/ViewModels/Settings/BehaviourViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/BehaviourViewModel.cs
@@ -14,10 +14,10 @@
             set => App.Settings.Prop.BackgroundUpdatesEnabled = value;
         }
 
-        public bool CacheDownloads
+        public bool DisableCachingDownloads
         {
-            get => App.Settings.Prop.CacheDownloads;
-            set => App.Settings.Prop.CacheDownloads = value;
+            get => App.Settings.Prop.DisableCachingDownloads;
+            set => App.Settings.Prop.DisableCachingDownloads = value;
         }
 
         public bool IsRobloxInstallationMissing => !App.IsPlayerInstalled && !App.IsStudioInstalled;


### PR DESCRIPTION
Closes https://github.com/bloxstraplabs/bloxstrap/issues/6252

Lets the user disable caching Roblox update packages.